### PR TITLE
Feature get server connected users

### DIFF
--- a/src/components/UserListItem/UserListItem.tsx
+++ b/src/components/UserListItem/UserListItem.tsx
@@ -1,0 +1,17 @@
+import { Badge } from "@mui/material";
+import { Link } from "react-router-dom";
+
+type UserListItemProps = {
+    userId: string,
+    userPseudo: string,
+    isConnected: boolean
+}
+
+export function UserListItem(props: UserListItemProps) {
+    console.log(props.isConnected);
+    return (
+        <Badge color="success" variant="dot" invisible={!props.isConnected} >
+            <Link to={`/user/${props.userId}`}>{props.userPseudo}</Link>
+        </Badge>
+    );
+}

--- a/src/components/UserListItem/UserListItem.tsx
+++ b/src/components/UserListItem/UserListItem.tsx
@@ -8,7 +8,6 @@ type UserListItemProps = {
 }
 
 export function UserListItem(props: UserListItemProps) {
-    console.log(props.isConnected);
     return (
         <Badge color="success" variant="dot" invisible={!props.isConnected} >
             <Link to={`/user/${props.userId}`}>{props.userPseudo}</Link>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -30,7 +30,7 @@ export default function Home() {
         ioClose();
       }
     }
-  }, [dispatch, serversStatus, ioClose]);
+  }, [dispatch, ioClose]);
 
   return (
     <div className="Home">

--- a/src/pages/ServerDisplay/ServerDisplay.scss
+++ b/src/pages/ServerDisplay/ServerDisplay.scss
@@ -1,13 +1,14 @@
+@use "../../styles/variables" as *;
 .ServerDisplay {
     display: flex;
     flex-direction: column;
 
     & a {
         text-decoration: none;
-        color: black;
+        color: var(--font-color);
 
         &:hover {
-            font-weight: bold;
+            text-shadow: var(--font-color) 1px 0 5px;
         }
     }
 
@@ -41,12 +42,9 @@
         &__members-box {
             border: 1px solid lightgray;
             width: fit-content;
-            text-align: center;
-
             .members-heading {
                 margin: 10px;
             }
-
             .members-stack {
                 width: fit-content;
                 padding: 5px 10px;
@@ -59,7 +57,6 @@
             min-height: 0;
             display: flex;
             flex-direction: column;
-
             & h4 {
                 text-align: center;
             }
@@ -67,7 +64,6 @@
 
         &__channels-box {
             border: 1px solid lightgray;
-
             & h4 {
                 margin: 10px;
             }
@@ -76,7 +72,6 @@
                 color: lightgrey;
                 cursor: pointer;
                 margin-left: 10px;
-
                 &:hover {
                     color: #999999;
                 }

--- a/src/pages/ServerDisplay/ServerDisplay.scss
+++ b/src/pages/ServerDisplay/ServerDisplay.scss
@@ -51,10 +51,11 @@
                 text-align: left;
                 .MuiBadge-root {
                     width: fit-content;
+                    margin-right: 0.5em;
                 }
                 .MuiBadge-dot {
                     top: 0.4em;
-                    right: -0.3em;
+                    right: -0.5em;
                 }
             }
         }

--- a/src/pages/ServerDisplay/ServerDisplay.scss
+++ b/src/pages/ServerDisplay/ServerDisplay.scss
@@ -49,6 +49,13 @@
                 width: fit-content;
                 padding: 5px 10px;
                 text-align: left;
+                .MuiBadge-root {
+                    width: fit-content;
+                }
+                .MuiBadge-dot {
+                    top: 0.4em;
+                    right: -0.3em;
+                }
             }
         }
 

--- a/src/pages/ServerDisplay/ServerDisplay.tsx
+++ b/src/pages/ServerDisplay/ServerDisplay.tsx
@@ -175,6 +175,7 @@ export default function ServerDisplay() {
         return () => {
             Socket.off('serverUserList');
             Socket.off('userJoined');
+            Socket.off('userLeft');
         }
         
       }, [urlSearchParams, authStatus, dispatch, usersState.data]);

--- a/src/pages/ServerDisplay/ServerDisplay.tsx
+++ b/src/pages/ServerDisplay/ServerDisplay.tsx
@@ -229,7 +229,7 @@ export default function ServerDisplay() {
                         <h4 className="members-heading">Users :</h4>
                         <Stack className="members-stack" spacing={0.8}>
                             {serverUsers.map(user => (
-                                <UserListItem userPseudo={user.pseudo} userId={user.id} isConnected={connectedUsers.includes(user.id)}/>
+                                <UserListItem key={`userBadge_${user.id}`} userPseudo={user.pseudo} userId={user.id} isConnected={connectedUsers.includes(user.id)}/>
                             ))}
                         </Stack>
                         {serverUsers.length > 0 && (

--- a/src/pages/ServerDisplay/ServerDisplay.tsx
+++ b/src/pages/ServerDisplay/ServerDisplay.tsx
@@ -1,5 +1,5 @@
 import { AxiosError } from "axios";
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useContext, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useParams } from "react-router-dom";
 
@@ -18,6 +18,7 @@ import { addUsers } from "../../redux/usersSlice";
 import { ServerService } from "../../services/serverService";
 
 import './ServerDisplay.scss';
+import IoSocketContext from "../../Contexts/IoSocketContext";
 
 const getServerData = async(serverId: string) => {
     try {
@@ -60,6 +61,7 @@ export default function ServerDisplay() {
     const [joinServerError, setJoinServerError] = useState<{isError:boolean, errorMessage:string}>({isError: false, errorMessage: ''});
     const [mainContent, setMainContent] = useState<string>('chat');
     const [channelId, setChannelId] = useState<string>("");
+    const Socket = useContext(IoSocketContext)!.Socket;
     
     const joinServer = async () => {
         try {
@@ -152,7 +154,17 @@ export default function ServerDisplay() {
             .catch(error => {
                 setServerError(error);
             });
-    }, [urlSearchParams, authStatus, dispatch, usersState.data]);
+        Socket.emit('getServerConnectedUsers', {serverId: urlSearchParams.serverId!});
+
+        Socket.on('serverUserList', (data:any) => {
+            console.log(data);
+        })
+
+        return () => {
+            Socket.off('serverUserList');
+        }
+        
+      }, [urlSearchParams, authStatus, dispatch, usersState.data]);
     
     return (
         <div className="ServerDisplay">

--- a/src/pages/ServerDisplay/ServerDisplay.tsx
+++ b/src/pages/ServerDisplay/ServerDisplay.tsx
@@ -63,7 +63,7 @@ export default function ServerDisplay() {
     const [joinServerError, setJoinServerError] = useState<{isError:boolean, errorMessage:string}>({isError: false, errorMessage: ''});
     const [mainContent, setMainContent] = useState<string>('chat');
     const [channelId, setChannelId] = useState<string>("");
-    const [connectedUsers, setConnectedUsers] = useState<string[]>([]);
+    const [connectedUsers, setConnectedUsers] = useState<string[]>([authStatus.user.id]);
     
     const joinServer = async () => {
         try {


### PR DESCRIPTION
In this feature, the ServerDisplay page now has a user list that shows if users are connected with a green badge.
When the component is mounted, a WS event is sent ( getServerConnectedUsers ) to backend.
In response, backend sends a 'serverUserList' event, containing the list of id of connected users.
When a user connects or disconnects, the backend sends events ( 'userJoined' or 'userLeft' ) containing the id of the user, so ServerDisplay components can update badges on the user list.