### PR TITLE
Fix re rendu des messages inutiles

### DIFF
--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios';
 import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-
+import React from 'react';
 import { Avatar, Snackbar } from '@mui/material';
 import parse, { Element } from 'html-react-parser';
 import { IMessage } from '../../interfaces/IMessage';
@@ -16,7 +16,10 @@ type messageType = {
     message: IMessage
 }
 
-export function Message({ message }: messageType) {
+export const MemorisedMessage = React.memo(Message);
+
+function Message({ message }: messageType) {
+    console.log("re rendu");
     const currentDate = new Date(Date.now()).toLocaleString('fr', { dateStyle: 'long' });
     const messageDate = new Date(message.createdAt!).toLocaleString('fr', { dateStyle: 'long' });
     const isToday = currentDate === messageDate;

--- a/src/components/Message/Message.tsx
+++ b/src/components/Message/Message.tsx
@@ -19,7 +19,6 @@ type messageType = {
 export const MemorisedMessage = React.memo(Message);
 
 function Message({ message }: messageType) {
-    console.log("re rendu");
     const currentDate = new Date(Date.now()).toLocaleString('fr', { dateStyle: 'long' });
     const messageDate = new Date(message.createdAt!).toLocaleString('fr', { dateStyle: 'long' });
     const isToday = currentDate === messageDate;

--- a/src/components/MessageBox/MessageBox.tsx
+++ b/src/components/MessageBox/MessageBox.tsx
@@ -19,7 +19,6 @@ type MessageBoxProps = {
 }
 
 export function MessageBox({ channelId, canUserPost }: MessageBoxProps) {
-    console.log("re render");
     const authStatus = useSelector((state: reduxData) => state.authStatus);
     const stateMessages = useSelector((state: reduxData) => state.messages);
     const [getMessagesError, setGetMessagesError] = useState<{ isError: boolean, errorMessage: string }>({ isError: false, errorMessage: '' });

--- a/src/components/MessageBox/MessageBox.tsx
+++ b/src/components/MessageBox/MessageBox.tsx
@@ -19,6 +19,7 @@ type MessageBoxProps = {
 }
 
 export function MessageBox({ channelId, canUserPost }: MessageBoxProps) {
+    console.log("re render");
     const authStatus = useSelector((state: reduxData) => state.authStatus);
     const stateMessages = useSelector((state: reduxData) => state.messages);
     const [getMessagesError, setGetMessagesError] = useState<{ isError: boolean, errorMessage: string }>({ isError: false, errorMessage: '' });

--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -7,7 +7,7 @@ import { Snackbar } from '@mui/material';
 import { MessageService } from '../../services/messageService';
 import { setMessages } from '../../redux/messagesSlice';
 import { IMessage } from '../../interfaces/IMessage';
-import { Message } from '../Message/Message';
+import { MemorisedMessage } from '../Message/Message';
 
 import './MessageList.scss';
 
@@ -65,7 +65,7 @@ export const MessageList = ({messages}: messageList) => {
     <div ref={element} className="MessageList" onScroll={handleScroll}>
       {messages && messages.map((message, index) => (
         <div key={message.id}>
-          <Message key={message.id} message={message} />
+          <MemorisedMessage key={message.id} message={message} />
           {index === messages.length - 1 && <div ref={messageEndRef} />}
         </div>
       ))}  


### PR DESCRIPTION
- Message is now a memorised component (call too as "pure component")
- <Message/> is now re render only if his "id" or "message" change. (which should be the case incase of a delete message (since id is "deleted"), content modification  or a new message) 

- Otherwise old "messages" aren't re render again :) 
